### PR TITLE
Prevent some emoji characters from being excluded from SVG text output

### DIFF
--- a/svgWriterUtils.js
+++ b/svgWriterUtils.js
@@ -230,8 +230,9 @@
                       .replace(/>/g, "&gt;")
                       .replace(/"/g, "&quot;")
                       .replace(/'/g, "&apos;")
-                      // XML char: #x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
-                      .replace(/[^\u0009\u000A\u000D\u0020-\uD7FF\uE000-\uFFFD\u10000-\u10FFFF]/g, "");
+                      // XML char: #x9 | #xA | #xD |
+                      // [#x20-#xDBFF] | [#xDC00-#xDFFF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]
+                      .replace(/[^\u0009\u000A\u000D\u0020-\uDBFF\uDC00-\uDFFF\uE000-\uFFFD\u10000-\u10FFFF]/g, "");
         };
 
         self.extend = Utils.extend;


### PR DESCRIPTION
This regex change was vetted by the WebPA folks.  The previous character exclusions were too broad, causing some emoji to be replaced with whitespace.