### PR TITLE
Treat background layer as a regular pixel layer when generating SVG data

### DIFF
--- a/generatorPlus.js
+++ b/generatorPlus.js
@@ -197,7 +197,8 @@
                     }
 
                     //bUnderRoot is to only crop to the sub-tree being generatored...
-                    if ((!cropToSingleLayer || bUnderRoot) && (layerType === "shapeLayer" || layerType === "textLayer" || layerType === "layer")) {
+                    if ((!cropToSingleLayer || bUnderRoot) && (layerType === "shapeLayer" || layerType === "textLayer" || layerType === "layer" ||
+                            layerType === "backgroundLayer")) {
 
                         Utils.extend(true, layer, { layerEffects: this.findCompLayerEffects(layer.id, layerComp) });
 

--- a/svgOMGenerator.js
+++ b/svgOMGenerator.js
@@ -26,7 +26,7 @@
         omgImage = require("./svgOMGeneratorImage.js"),
         omgStyles = require("./svgOMGeneratorStyles.js"),
         layerTypeMap = {
-            backgroundLayer: "background",
+            backgroundLayer: "image", // treat background layers as images
             shapeLayer: "shape",
             textLayer: "text",
             layerSection: "group",


### PR DESCRIPTION
Previously, background layers were explicitly ignored.  No one remembers why.

Background layers are still treated specially with respect to the effect on layer indexing.  But otherwise a BG layer will have its pixel data fetched from PS and embedded in the SVG as though it was a standard pixel layer.

internal ref: PS-20506